### PR TITLE
build: adds dependabot def

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - FocusFish/uvmsdevs
+  - package-ecosystem: npm
+    directory: "/app"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - FocusFish/uvmsdevs


### PR DESCRIPTION
Dependabot will check for updates for both maven and npm dependencies.

Refs: FART-552